### PR TITLE
Add check for blank name coming from WP->Civi

### DIFF
--- a/civicrm-wp-profile-sync.php
+++ b/civicrm-wp-profile-sync.php
@@ -758,6 +758,9 @@ class CiviCRM_WP_Profile_Sync {
 
 		// Check if this is a BuddyPress General Settings update.
 		if ( function_exists( 'bp_is_current_action' ) AND bp_is_current_action( 'general' ) ) return;
+		
+		// Bail if no name, as we don't want to overwrite Civi with blank values.
+		if (!$user->first_name && !$user->last_name) return;
 
 		// Update the CiviCRM Contact first name and last name.
 		$contact = civicrm_api( 'contact', 'create', array(


### PR DESCRIPTION
We had an issue where names in Civi were getting overwritten by blank values. This happened if:

--the WP User had a blank name (somehow)
--the Civi user did not
--a password reset was requested

The reset triggers something which fires a profile sync, overwriting the name in Civi. 

I can't *think* of a situation where you'd want this to happen, so figured updating this plugin was the best approach. But happy to be corrected if you think it's not logical.