### PR TITLE
allow syncing 'telephone' xProfile type

### DIFF
--- a/assets/js/buddypress/xprofile/cwps-bp-civicrm-field.js
+++ b/assets/js/buddypress/xprofile/cwps-bp-civicrm-field.js
@@ -163,6 +163,9 @@ var CWPS_BP_Field = CWPS_BP_Field || {};
 		 */
 		this.get_options_for = function( entity ) {
 			var options = me.get_setting('options');
+			if (me.field_type == 'telephone') {
+				me.field_type = 'textbox';
+			}
 			if ( options[me.field_type] ) {
 				if ( options[me.field_type][entity] ) {
 					return options[me.field_type][entity];


### PR DESCRIPTION
xProfile fields of type `telephone` can't be synced to CiviCRM because `get_options_for` doesn't know they should be syncable with the same fields as type `textbox`.