### PR TITLE
CiviCRM Profile Sync will remove CiviCRM Contact First Name and Last Name if WordPress User fields are not set

### DIFF
--- a/includes/civicrm/cwps-civicrm-contact.php
+++ b/includes/civicrm/cwps-civicrm-contact.php
@@ -513,6 +513,11 @@ class CiviCRM_WP_Profile_Sync_CiviCRM_Contact {
 			return;
 		}
 
+		// Check if the first name or last name is empty, both values are required to update a CiviCRM Contact
+		if (empty($user->first_name) || empty($user->last_name)) {
+			return;
+		}
+
 		// Update the CiviCRM Contact "First Name" and "Last Name".
 		$params = [
 			'version' => 3,
@@ -541,7 +546,7 @@ class CiviCRM_WP_Profile_Sync_CiviCRM_Contact {
 
 
 	/**
-	 * Check if a CiviCRM Contact's name should by synced.
+	 * Check if a CiviCRM Contact's name should be synced.
 	 *
 	 * @since 0.3
 	 *


### PR DESCRIPTION
CiviCRM Profile Sync will remove CiviCRM Contact First Name and Last Name if WordPress User fields are not set.

Agileware Ref: CIVIWPSYNC-1