### PR TITLE
Overhaul custom field sync for BuddyPress

### DIFF
--- a/includes/buddypress/cwps-bp-civicrm-custom-field.php
+++ b/includes/buddypress/cwps-bp-civicrm-custom-field.php
@@ -80,6 +80,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		'Money',
 		'Country',
 		'StateProvince',
+		'Boolean',
 	];
 
 	/**
@@ -160,10 +161,8 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		add_filter( 'cwps/bp/field/query_setting_choices', [ $this, 'query_setting_choices' ], 100, 4 );
 
 		// Filter the "CiviCRM Field" select to include only Custom Fields of the right type on the "Edit Field" sceen.
-		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'checkbox_settings_filter' ], 10, 3 );
 		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'select_settings_filter' ], 10, 3 );
 		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'multiselect_settings_filter' ], 10, 3 );
-		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'radio_settings_filter' ], 10, 3 );
 		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'date_settings_filter' ], 10, 3 );
 		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'text_settings_filter' ], 10, 3 );
 		add_filter( 'cwps/bp/query_settings/custom_fields_filter', [ $this, 'textarea_settings_filter' ], 10, 3 );
@@ -644,86 +643,13 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 
 		// Get keyed array of settings.
-		$options = $this->checkbox_choices_get( $custom_field_id );
+		$options = $this->choices_get( $custom_field_id );
 
 		// --<
 		return $options;
 
 	}
 
-	/**
-	 * Get the choices for the Setting of a "Checkbox" Field.
-	 *
-	 * @since 0.5
-	 *
-	 * @param string $custom_field_id The numeric ID of the CiviCRM Custom Field.
-	 * @return array $choices The choices for the Field.
-	 */
-	public function checkbox_choices_get( $custom_field_id ) {
-
-		// Init return.
-		$choices = [];
-
-		// Get Custom Field data.
-		$field_data = $this->plugin->civicrm->custom_field->get_by_id( $custom_field_id );
-
-		// Bail if we don't get any.
-		if ( false === $field_data ) {
-			return $choices;
-		}
-
-		// Bail if it's not "String".
-		if ( 'String' !== $field_data['data_type'] ) {
-			return $choices;
-		}
-
-		// Bail if it's not "CheckBox".
-		if ( 'CheckBox' !== $field_data['html_type'] ) {
-			return $choices;
-		}
-
-		// Get options.
-		if ( ! empty( $field_data['option_group_id'] ) ) {
-			$choices = CRM_Core_OptionGroup::valuesByID( (int) $field_data['option_group_id'] );
-		}
-
-		// --<
-		return $choices;
-
-	}
-
-	/**
-	 * Filter the Custom Fields for the Setting of a "CheckBox" Field.
-	 *
-	 * @since 0.5
-	 *
-	 * @param array  $filtered_fields The existing array of filtered Custom Fields.
-	 * @param array  $custom_fields The array of Custom Fields.
-	 * @param string $field_type The BuddyPress Field Type.
-	 * @return array $filtered_fields The modified array of filtered Custom Fields.
-	 */
-	public function checkbox_settings_filter( $filtered_fields, $custom_fields, $field_type ) {
-
-		// Bail early if not our Field Type.
-		if ( 'checkbox' !== $field_type ) {
-			return $filtered_fields;
-		}
-
-		// Filter Fields to include only Boolean/Radio.
-		foreach ( $custom_fields as $custom_group_name => $custom_group ) {
-			foreach ( $custom_group as $custom_field ) {
-				if ( ! empty( $custom_field['data_type'] ) && 'String' === $custom_field['data_type'] ) {
-					if ( ! empty( $custom_field['html_type'] ) && 'CheckBox' === $custom_field['html_type'] ) {
-						$filtered_fields[ $custom_group_name ][] = $custom_field;
-					}
-				}
-			}
-		}
-
-		// --<
-		return $filtered_fields;
-
-	}
 
 	/**
 	 * Modify the Options of a BuddyPress "Select" Field.
@@ -748,7 +674,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 
 		// Get keyed array of settings.
-		$options = $this->select_choices_get( $custom_field_id );
+		$options = $this->choices_get( $custom_field_id );
 
 		// --<
 		return $options;
@@ -756,14 +682,14 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 	}
 
 	/**
-	 * Get the choices for the Setting of a "Select" Field.
+	 * Get the choices for the Setting of a single-value Field.
 	 *
 	 * @since 0.5
 	 *
 	 * @param string $custom_field_id The numeric ID of the CiviCRM Custom Field.
 	 * @return array $choices The choices for the Field.
 	 */
-	public function select_choices_get( $custom_field_id ) {
+	public function choices_get( $custom_field_id ) {
 
 		// Init return.
 		$choices = [];
@@ -776,13 +702,8 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 			return $choices;
 		}
 
-		// Bail if it's not a data type that can have a "Select".
+		// Bail if it's not a data type that can have multiple choices.
 		if ( ! in_array( $field_data['data_type'], $this->data_types, true ) ) {
-			return $choices;
-		}
-
-		// Bail if it's not a type of "Select".
-		if ( ! in_array( $field_data['html_type'], $this->select_types, true ) ) {
 			return $choices;
 		}
 
@@ -792,15 +713,17 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 
 		// "Country" selects require special handling.
-		$country_selects = [ 'Select Country', 'Multi-Select Country' ];
-		if ( in_array( $field_data['html_type'], $country_selects, true ) ) {
+		if ( $field_data['data_type'] === 'Country' ) {
 			$choices = CRM_Core_PseudoConstant::country();
 		}
 
 		// "State/Province" selects also require special handling.
-		$state_selects = [ 'Select State/Province', 'Multi-Select State/Province' ];
-		if ( in_array( $field_data['html_type'], $state_selects, true ) ) {
+		if ( $field_data['data_type'] === 'StateProvince' ) {
 			$choices = CRM_Core_PseudoConstant::stateProvince();
+		}
+
+		if ( $field_data['data_type'] === 'Boolean' ) {
+			$choices = [0 => 'No', 1 => 'Yes'];
 		}
 
 		// --<
@@ -809,7 +732,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 	}
 
 	/**
-	 * Filter the Custom Fields for the Setting of a "Select" Field.
+	 * Filter the Custom Fields for the Setting of a single-value field.
 	 *
 	 * @since 0.5
 	 *
@@ -821,7 +744,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 	public function select_settings_filter( $filtered_fields, $custom_fields, $field_type ) {
 
 		// Bail early if not our Field Type.
-		if ( 'selectbox' !== $field_type ) {
+		if ( !in_array($field_type, ['selectbox', 'radio'] )) {
 			return $filtered_fields;
 		}
 
@@ -835,16 +758,14 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 		*/
 
-		// Filter Fields to include only "Select" types.
-		$select_types = [ 'Select', 'Select Country', 'Select State/Province' ];
+		// Filter Fields to include only single-value types.
+		$select_types = [ 'Select', 'Radio' ];
 
 		// Filter Fields to include only those which are compatible.
 		foreach ( $custom_fields as $custom_group_name => $custom_group ) {
 			foreach ( $custom_group as $custom_field ) {
-				if ( ! empty( $custom_field['data_type'] ) && in_array( $custom_field['data_type'], $this->data_types, true ) ) {
-					if ( ! empty( $custom_field['html_type'] ) && in_array( $custom_field['html_type'], $select_types, true ) ) {
-						$filtered_fields[ $custom_group_name ][] = $custom_field;
-					}
+				if (isset($custom_field['serialize']) && (int) $custom_field['serialize'] === 0) {
+					$filtered_fields[ $custom_group_name ][] = $custom_field;
 				}
 			}
 		}
@@ -877,7 +798,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 
 		// Get keyed array of settings.
-		$options = $this->select_choices_get( $custom_field_id );
+		$options = $this->choices_get( $custom_field_id );
 
 		// --<
 		return $options;
@@ -885,7 +806,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 	}
 
 	/**
-	 * Filter the Custom Fields for the Setting of a "Multi Select Box" Field.
+	 * Filter the Custom Fields for the Setting of a multi-value field.
 	 *
 	 * @since 0.5
 	 *
@@ -897,20 +818,15 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 	public function multiselect_settings_filter( $filtered_fields, $custom_fields, $field_type ) {
 
 		// Bail early if not our Field Type.
-		if ( 'multiselectbox' !== $field_type ) {
+		if ( !in_array($field_type, ['multiselectbox', 'checkbox'] )) {
 			return $filtered_fields;
 		}
-
-		// Filter Fields to include only "Multi-Select" types.
-		$select_types = [ 'Multi-Select', 'Multi-Select Country', 'Multi-Select State/Province' ];
 
 		// Filter Fields to include only those which are compatible.
 		foreach ( $custom_fields as $custom_group_name => $custom_group ) {
 			foreach ( $custom_group as $custom_field ) {
-				if ( ! empty( $custom_field['data_type'] ) && in_array( $custom_field['data_type'], $this->data_types, true ) ) {
-					if ( ! empty( $custom_field['html_type'] ) && in_array( $custom_field['html_type'], $select_types, true ) ) {
-						$filtered_fields[ $custom_group_name ][] = $custom_field;
-					}
+				if (isset($custom_field['serialize']) && (int) $custom_field['serialize'] === 1) {
+					$filtered_fields[ $custom_group_name ][] = $custom_field;
 				}
 			}
 		}
@@ -943,84 +859,10 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 		}
 
 		// Get keyed array of settings.
-		$options = $this->radio_choices_get( $custom_field_id );
+		$options = $this->choices_get( $custom_field_id );
 
 		// --<
 		return $options;
-
-	}
-
-	/**
-	 * Get the choices for the Setting of a "Radio" Field.
-	 *
-	 * @since 0.5
-	 *
-	 * @param string $custom_field_id The numeric ID of the CiviCRM Custom Field.
-	 * @return array $choices The choices for the Field.
-	 */
-	public function radio_choices_get( $custom_field_id ) {
-
-		// Init return.
-		$choices = [];
-
-		// Get Custom Field data.
-		$field_data = $this->plugin->civicrm->custom_field->get_by_id( $custom_field_id );
-
-		// Bail if we don't get any.
-		if ( false === $field_data ) {
-			return $choices;
-		}
-
-		// Bail if it's not a data type that can have a "Radio" sub-type.
-		if ( ! in_array( $field_data['data_type'], $this->data_types, true ) ) {
-			return $choices;
-		}
-
-		// Bail if it's not "Radio".
-		if ( 'Radio' !== $field_data['html_type'] ) {
-			return $choices;
-		}
-
-		// Get options.
-		if ( ! empty( $field_data['option_group_id'] ) ) {
-			$choices = CRM_Core_OptionGroup::valuesByID( (int) $field_data['option_group_id'] );
-		}
-
-		// --<
-		return $choices;
-
-	}
-
-	/**
-	 * Filter the Custom Fields for the Setting of a "Radio" Field.
-	 *
-	 * @since 0.5
-	 *
-	 * @param array  $filtered_fields The existing array of filtered Custom Fields.
-	 * @param array  $custom_fields The array of Custom Fields.
-	 * @param string $field_type The BuddyPress Field Type.
-	 * @return array $filtered_fields The modified array of filtered Custom Fields.
-	 */
-	public function radio_settings_filter( $filtered_fields, $custom_fields, $field_type ) {
-
-		// Bail early if not our Field Type.
-		if ( 'radio' !== $field_type ) {
-			return $filtered_fields;
-		}
-
-		// Filter Fields to include only "Radio" HTML types.
-		foreach ( $custom_fields as $custom_group_name => $custom_group ) {
-			foreach ( $custom_group as $custom_field ) {
-				if ( ! empty( $custom_field['data_type'] ) && in_array( $custom_field['data_type'], $this->data_types, true ) ) {
-					if ( ! empty( $custom_field['html_type'] ) && 'Radio' === $custom_field['html_type'] ) {
-						$filtered_fields[ $custom_group_name ][] = $custom_field;
-					}
-				}
-			}
-		}
-
-		// --<
-		return $filtered_fields;
 
 	}
 
@@ -1082,7 +924,7 @@ class CiviCRM_Profile_Sync_BP_CiviCRM_Custom_Field {
 
 		/*
 		// Get keyed array of settings.
-		$options = $this->radio_choices_get( $custom_field_id );
+		$options = $this->choices_get( $custom_field_id );
 		*/
 
 		// --<

--- a/includes/buddypress/cwps-bp-xprofile.php
+++ b/includes/buddypress/cwps-bp-xprofile.php
@@ -563,14 +563,8 @@ class CiviCRM_Profile_Sync_BP_XProfile {
 			$value = '';
 		}
 
-		// Do not trigger our filter.
-		remove_filter( 'bp_xprofile_set_field_data_pre_validate', [ $this, 'pre_validate' ], 10 );
-
 		// Pass through to BuddyPress.
 		$result = xprofile_set_field_data( $field_id, $user_id, $value );
-
-		// Reinstate our filter.
-		add_filter( 'bp_xprofile_set_field_data_pre_validate', [ $this, 'pre_validate' ], 10, 3 );
 
 		// --<
 		return $result;


### PR DESCRIPTION
Hi Christian,

This is a PR to fix/overhaul the custom field sync choices for BuddyPress/xProfile.

The primary benefit is that this conforms to modern Civi custom field structure.  E.g. the value of `serialize` determines whether a field is multi-select or not - and the "Select Country" etc. no longer exist as HTML types.

I also saw that a radio field in Civi would only map to a radio field, and not a select field.  I'm not sure if there's a specific reason for that?  In Webform-CiviCRM, I commonly change the front-end UI of a field, so I loosened all of that up.

I also added support for syncing with Boolean fields.

This allowed me to remove a whole lot of code - and we can probably go further, but I wanted to see if these changes were broadly acceptable to you.