### PR TITLE
Fix dynamic property creation in Activity and Case ACFE Action when a…

### DIFF
--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-activity.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-activity.php
@@ -240,7 +240,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Activity extends CiviCRM_Profile
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-case.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-case.php
@@ -48,15 +48,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Case extends CiviCRM_Profile_Syn
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.5
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.5

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-case.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-case.php
@@ -248,7 +248,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Case extends CiviCRM_Profile_Syn
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-contact.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-contact.php
@@ -48,15 +48,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Contact extends CiviCRM_Profile_
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.5
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.5
@@ -380,7 +371,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Contact extends CiviCRM_Profile_
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-email.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-email.php
@@ -48,15 +48,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Email extends CiviCRM_Profile_Sy
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.5
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.5
@@ -123,7 +114,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Email extends CiviCRM_Profile_Sy
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-event.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-event.php
@@ -48,15 +48,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Event extends CiviCRM_Profile_Sy
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.5.4
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.5.4
@@ -395,7 +386,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Event extends CiviCRM_Profile_Sy
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-participant.php
+++ b/includes/acf/acfe/form-actions/acfe-0.8.x/cwps-acf-acfe-form-action-participant.php
@@ -48,15 +48,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Participant extends CiviCRM_Prof
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.5
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.5
@@ -290,7 +281,6 @@ class CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Participant extends CiviCRM_Prof
 		$this->plugin     = $parent->acf_loader->plugin;
 		$this->acf_loader = $parent->acf_loader;
 		$this->acfe       = $parent->acfe;
-		$this->form       = $parent;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-activity.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-activity.php
@@ -166,7 +166,6 @@ class CWPS_ACF_ACFE_Form_Action_Activity extends CWPS_ACF_ACFE_Form_Action_Base 
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-base.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-base.php
@@ -48,15 +48,6 @@ class CWPS_ACF_ACFE_Form_Action_Base extends acfe_module_form_action {
 	public $acfe;
 
 	/**
-	 * ACFE Form object.
-	 *
-	 * @since 0.7.0
-	 * @access public
-	 * @var CiviCRM_Profile_Sync_ACF_ACFE_Form
-	 */
-	public $form;
-
-	/**
 	 * CiviCRM object.
 	 *
 	 * @since 0.7.0

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-case.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-case.php
@@ -174,7 +174,6 @@ class CWPS_ACF_ACFE_Form_Action_Case extends CWPS_ACF_ACFE_Form_Action_Base {
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-contact.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-contact.php
@@ -306,7 +306,6 @@ class CWPS_ACF_ACFE_Form_Action_Contact extends CWPS_ACF_ACFE_Form_Action_Base {
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-email.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-email.php
@@ -58,7 +58,6 @@ class CWPS_ACF_ACFE_Form_Action_Email extends CWPS_ACF_ACFE_Form_Action_Base {
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-event.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-event.php
@@ -321,7 +321,6 @@ class CWPS_ACF_ACFE_Form_Action_Event extends CWPS_ACF_ACFE_Form_Action_Base {
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.

--- a/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-participant.php
+++ b/includes/acf/acfe/form-actions/acfe-0.9.x/cwps-acf-acfe-form-action-participant.php
@@ -216,7 +216,6 @@ class CWPS_ACF_ACFE_Form_Action_Participant extends CWPS_ACF_ACFE_Form_Action_Ba
 		$this->plugin     = civicrm_wp_profile_sync();
 		$this->acf_loader = $this->plugin->acf;
 		$this->acfe       = $this->acf_loader->acfe;
-		$this->form       = $this->acfe->form;
 		$this->civicrm    = $this->acf_loader->civicrm;
 
 		// Label this Form Action.


### PR DESCRIPTION
…cfe < 0.9

This aims to fix the following notice

```
Creation of dynamic property CiviCRM_Profile_Sync_ACF_ACFE_Form_Action_Activity::$form is deprecated
```

As best as I can tell in these classes the form property isn't being accessed thoughts @christianwach 